### PR TITLE
Improve fence detection by checking line starts

### DIFF
--- a/aider/coders/base_coder.py
+++ b/aider/coders/base_coder.py
@@ -485,23 +485,27 @@ class Coder:
                 yield fname, content
 
     def choose_fence(self):
-        all_content = ""
+        all_lines = []
         for _fname, content in self.get_abs_fnames_content():
-            all_content += content + "\n"
+            all_lines.extend(content.splitlines())
         for _fname in self.abs_read_only_fnames:
             content = self.io.read_text(_fname)
             if content is not None:
-                all_content += content + "\n"
+                all_lines.extend(content.splitlines())
 
-        good = False
+        good_fence = None
         for fence_open, fence_close in self.fences:
-            if fence_open in all_content or fence_close in all_content:
-                continue
-            good = True
-            break
+            is_bad = False
+            for line in all_lines:
+                if line.startswith(fence_open) or line.startswith(fence_close):
+                    is_bad = True
+                    break
+            if not is_bad:
+                good_fence = (fence_open, fence_close)
+                break
 
-        if good:
-            self.fence = (fence_open, fence_close)
+        if good_fence:
+            self.fence = good_fence
         else:
             self.fence = self.fences[0]
             self.io.tool_warning(


### PR DESCRIPTION
Update `choose_fence` to check for fence delimiters at the start of lines to improve accuracy.

---
<a href="https://cursor.com/background-agent?bcId=bc-469e4a97-366d-461f-bed6-163a808b7a4e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-469e4a97-366d-461f-bed6-163a808b7a4e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

